### PR TITLE
Allow overriding Chrome path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,18 @@ A proof-of-concept framework for automating tasks on a Windows machine. Tasks ar
 2. Build and run the `Automation.Runner` project with `dotnet run`.
 3. Inspect the console output and generated files to verify behaviour.
 
+### Configuring Chrome
+
+The CDP engine uses Google Chrome for browser automation. By default it will try
+to locate `chrome.exe` in the standard installation directories. You can
+override this by setting the `CHROME_EXECUTABLE` environment variable to the
+full path of your Chrome installation, e.g.
+
+```powershell
+$env:CHROME_EXECUTABLE="C:\Program Files\Google\Chrome\Application\chrome.exe"
+```
+
+If the variable is not set and Chrome cannot be found, PuppeteerSharp will fall
+back to downloading its own copy under the application's output folder.
+
 > **Note:** the repository does not include the .NET SDK. Install the SDK to build or run the project locally.

--- a/src/Automation.Engines/Automation.Engine.CDP/CDPAutomationEngine.cs
+++ b/src/Automation.Engines/Automation.Engine.CDP/CDPAutomationEngine.cs
@@ -1,6 +1,7 @@
 ﻿using Automation.Abstractions;
 using PuppeteerSharp;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace Automation.Engines.CDP
@@ -11,13 +12,34 @@ namespace Automation.Engines.CDP
         private IPage? _page;
         private const int DebugPort = 9222;
         private const string ProfilePath = "Profile 1";
+        private readonly string? _chromePath = GetChromeExecutable();
+
+        private static string? GetChromeExecutable()
+        {
+            var env = Environment.GetEnvironmentVariable("CHROME_EXECUTABLE");
+            if (!string.IsNullOrEmpty(env) && File.Exists(env))
+                return env;
+
+            var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            var defaultPath = Path.Combine(programFiles, "Google", "Chrome", "Application", "chrome.exe");
+            if (File.Exists(defaultPath))
+                return defaultPath;
+
+            var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            var defaultPathX86 = Path.Combine(programFilesX86, "Google", "Chrome", "Application", "chrome.exe");
+            if (File.Exists(defaultPathX86))
+                return defaultPathX86;
+
+            return null;
+        }
 
         public void LaunchChromeWithDebugging()
         {
+            var exe = _chromePath ?? "chrome.exe";
             Process.Start(new ProcessStartInfo
             {
-                FileName = "chrome.exe",
-                Arguments = $"--remote-debugging-port={DebugPort} --profile-directory=\"{ProfilePath}\"", //--user-data-dir=\"{ProfilePath}\" 
+                FileName = exe,
+                Arguments = $"--remote-debugging-port={DebugPort} --profile-directory=\"{ProfilePath}\"",
                 UseShellExecute = true
             });
         }
@@ -38,13 +60,14 @@ namespace Automation.Engines.CDP
                 _browser = await Puppeteer.LaunchAsync(new LaunchOptions
                 {
                     Headless = false,
+                    ExecutablePath = _chromePath,
                     Args = new[]
-    {
-        "--start-maximized",         // open the window maximized
-        "--remote-debugging-port=9222",
-        $"--user-data-dir={ProfilePath}",
+                    {
+                        "--start-maximized",         // open the window maximized
+                        "--remote-debugging-port=9222",
+                        $"--user-data-dir={ProfilePath}",
      //   $"--profile-directory={ProfileDirectory}"
-    }
+                    }
                 });
             }
 


### PR DESCRIPTION
## Summary
- add environment-based Chrome detection so you can launch installed Chrome instead of the bundled version
- document how to set `CHROME_EXECUTABLE`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e0836755083248e321df04b3fbeee