### PR TITLE
Add BrowserData using for Chrome build id

### DIFF
--- a/src/Automation.Engines/Automation.Engine.CDP/CDPAutomationEngine.cs
+++ b/src/Automation.Engines/Automation.Engine.CDP/CDPAutomationEngine.cs
@@ -1,5 +1,6 @@
 ﻿using Automation.Abstractions;
 using PuppeteerSharp;
+using PuppeteerSharp.BrowserData;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/src/Automation.Engines/Automation.Engine.CDP/ChromeFinder.cs
+++ b/src/Automation.Engines/Automation.Engine.CDP/ChromeFinder.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using PuppeteerSharp;
+using PuppeteerSharp.BrowserData;
 
 namespace Automation.Engines.CDP
 {


### PR DESCRIPTION
## Summary
- include `PuppeteerSharp.BrowserData` in CDPAutomationEngine
- include `PuppeteerSharp.BrowserData` in ChromeFinder

## Testing
- `dotnet build src/Automation.Engines/Automation.Engine.CDP/Automation.Engine.CDP.csproj`
- `dotnet build AutomationSolution.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853306d29fc832494ede5255aebaf7e