### PR TITLE
Add platform checks for UIAutomation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A proof-of-concept framework for automating tasks on a Windows machine. Tasks are defined as small classes implementing `IAutomationTask` and executed through a simple workflow engine.
 
+> **Note:** The default `Automation.Runner` project and the `UIAutomationEngine` require Windows. On other platforms they will throw a `PlatformNotSupportedException` during initialization.
+
 ## Features
 
 - `AutomationContext` for sharing data between tasks

--- a/src/Automation.Engines/Automation.Engine.UIAutomation/UIAutomationEngine.cs
+++ b/src/Automation.Engines/Automation.Engine.UIAutomation/UIAutomationEngine.cs
@@ -11,6 +11,10 @@ namespace Automation.Engines.UIAutomation
 
         public Task InitializeAsync()
         {
+            if (!OperatingSystem.IsWindows())
+                throw new PlatformNotSupportedException(
+                    "UIAutomationEngine is only supported on Windows platforms.");
+
             _root = AutomationElement.RootElement;
             if (_root == null)
                 throw new InvalidOperationException("UI Automation RootElement not available.");


### PR DESCRIPTION
## Summary
- fail initialization on non-Windows platforms
- document Windows requirement for UIAutomationRunner

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853324acff883249d90161c0c4f1be7