### PR TITLE
Handle download errors

### DIFF
--- a/src/Automation.Tasks/DownloadFileTask.cs
+++ b/src/Automation.Tasks/DownloadFileTask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -10,7 +11,12 @@ namespace Automation.Tasks
     /// </summary>
     public class DownloadFileTask : IAutomationTask
     {
-        private static readonly HttpClient _client = new();
+        private readonly HttpClient _client;
+
+        public DownloadFileTask(HttpClient? client = null)
+        {
+            _client = client ?? new HttpClient();
+        }
 
         public async Task ExecuteAsync(AutomationContext context)
         {
@@ -19,9 +25,17 @@ namespace Automation.Tasks
                 return;
 
             var path = context.Get<string>("download-path") ?? "download.bin";
-            var data = await _client.GetByteArrayAsync(url);
-            await File.WriteAllBytesAsync(path, data);
-            context.Set("downloaded-file", path);
+            try
+            {
+                var data = await _client.GetByteArrayAsync(url);
+                await File.WriteAllBytesAsync(path, data);
+                context.Set("downloaded-file", path);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"DownloadFileTask error: {ex.Message}");
+                context.Set("download-error", ex.Message);
+            }
         }
     }
 }

--- a/tests/Automation.Tests/DownloadFileTaskTests.cs
+++ b/tests/Automation.Tests/DownloadFileTaskTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Core;
+using Automation.Tasks;
+using Xunit;
+
+public class DownloadFileTaskTests
+{
+    private class FailingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("network failure");
+        }
+    }
+
+    [Fact]
+    public async Task Sets_error_message_when_download_fails()
+    {
+        var context = new AutomationContext();
+        context.Set("download-url", "http://example.com");
+        context.Set("download-path", "dummy.bin");
+
+        var client = new HttpClient(new FailingHandler());
+        var task = new DownloadFileTask(client);
+
+        await task.ExecuteAsync(context);
+
+        Assert.Equal("network failure", context.Get<string>("download-error"));
+        Assert.Null(context.Get<string>("downloaded-file"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle errors when downloading files
- add unit test for DownloadFileTask on network failures

## Testing
- `dotnet test tests/Automation.Tests/Automation.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6853324532b0832495c75da88659f4e2