### PR TITLE
Decouple core from Semantic Kernel

### DIFF
--- a/src/Automation.Core/Automation.Core.csproj
+++ b/src/Automation.Core/Automation.Core.csproj
@@ -2,7 +2,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Automation.Abstractions\Automation.Abstractions.csproj" />
-    <ProjectReference Include="..\Automation.Integrations\Automation.SemanticKernel\Automation.SemanticKernel.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Automation.Core/PluginLoader.cs
+++ b/src/Automation.Core/PluginLoader.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Reflection;
 using Automation.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,7 +15,12 @@ namespace Automation.Core
         public static void LoadPlugins(IServiceCollection services, string pluginDirectory)
         {
             // register built-in integrations shipped with the framework
-            RegisterTypesFromAssembly(services, typeof(Automation.SemanticKernel.SemanticKernelTask).Assembly);
+            var skPath = Path.Combine(AppContext.BaseDirectory, "Automation.SemanticKernel.dll");
+            if (File.Exists(skPath))
+            {
+                var assembly = Assembly.LoadFrom(skPath);
+                RegisterTypesFromAssembly(services, assembly);
+            }
 
             if (!Directory.Exists(pluginDirectory))
                 return;

--- a/src/Automation.Integrations/Automation.SemanticKernel/Automation.SemanticKernel.csproj
+++ b/src/Automation.Integrations/Automation.SemanticKernel/Automation.SemanticKernel.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Automation.Abstractions\Automation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Automation.Core\Automation.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove Semantic Kernel references from Automation.Core project
- dynamically load Semantic Kernel integrations if present
- reference Automation.Core from SemanticKernel project

## Testing
- `dotnet test tests/Automation.Tests/Automation.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853388379cc8324915ef8e65a6c75e4