### PR TITLE
Fix IAutomationFactory namespace

### DIFF
--- a/ConsoleRunner/Program.cs
+++ b/ConsoleRunner/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Automation.Core;
+using Automation.Abstractions;
 using Automation.Tasks;
 using Automation.Engines.CDP;
 using Microsoft.Extensions.DependencyInjection;

--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Automation.Core;
+using Automation.Abstractions;
 using Automation.Tasks;
 using Automation.Engines.CDP;
 using Automation.Engines.UIAutomation;

--- a/src/Automation.Abstractions/IAutomationFactory.cs
+++ b/src/Automation.Abstractions/IAutomationFactory.cs
@@ -1,7 +1,6 @@
 ﻿using Automation.Abstractions;
-using Automation.Core;
 
-namespace Automation.Core
+namespace Automation.Abstractions
 {
     /// <summary>
     /// Factory that can create and initialize IAutomationEngine instances by type.


### PR DESCRIPTION
## Summary
- move `IAutomationFactory` to `Automation.Abstractions` namespace
- import the new namespace in runner programs

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533e1be1dc8324a35b8e5897517b82