### PR TITLE
Improve workflow type resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A proof-of-concept framework for automating tasks on a Windows machine. Tasks ar
   - `SleepTask` – pauses for a configurable time
   - `DownloadFileTask` – downloads a file from a URL
 - Plugin loader for discovering additional tasks or engines from a `plugins` directory
+- Custom tasks must be loaded (for example registered with DI or via the plugin loader) before parsing a workflow so their assemblies are already loaded
 - Workflow definitions can be specified in `workflow.json`
 
 ## Usage

--- a/src/Automation.Core/WorkflowLoader.cs
+++ b/src/Automation.Core/WorkflowLoader.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Text.Json;
 
 namespace Automation.Core
@@ -12,7 +14,12 @@ namespace Automation.Core
             var items = JsonSerializer.Deserialize<List<WorkflowStepDto>>(json) ?? new();
             foreach (var i in items)
             {
-                var type = Type.GetType(i.TaskType) ?? throw new InvalidOperationException($"Task type {i.TaskType} not found");
+                var type = Type.GetType(i.TaskType)
+                    ?? AppDomain.CurrentDomain.GetAssemblies()
+                        .Select(a => a.GetType(i.TaskType))
+                        .FirstOrDefault(t => t != null)
+                    ?? throw new InvalidOperationException($"Task type {i.TaskType} not found");
+
                 yield return new WorkflowStep(i.Id, type, i.Dependencies ?? Array.Empty<string>(), i.Priority);
             }
         }

--- a/tests/Automation.Tests/WorkflowLoaderTests.cs
+++ b/tests/Automation.Tests/WorkflowLoaderTests.cs
@@ -1,0 +1,26 @@
+using Automation.Core;
+using Automation.Tasks;
+using System;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace Automation.Tests;
+
+public class WorkflowLoaderTests
+{
+    [Fact]
+    public void Resolves_Tasks_From_Loaded_Assemblies()
+    {
+        var json = JsonSerializer.Serialize(new[]
+        {
+            new { Id = "step", TaskType = typeof(WriteFileTask).FullName, Dependencies = Array.Empty<string>(), Priority = 0 }
+        });
+
+        var steps = WorkflowLoader.FromJson(json).ToList();
+
+        Assert.Single(steps);
+        Assert.Equal(typeof(WriteFileTask), steps[0].TaskType);
+    }
+}
+


### PR DESCRIPTION
## Summary
- broaden workflow type lookup to scan loaded assemblies
- add a WorkflowLoader test for tasks in other assemblies
- document that tasks must be loaded before parsing workflows

## Testing
- `dotnet test tests/Automation.Tests/Automation.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68533ee8b05c832491439e1e09969a6c